### PR TITLE
Add points view for Michigan States

### DIFF
--- a/src/calculators/BarnesPointsCalc.ts
+++ b/src/calculators/BarnesPointsCalc.ts
@@ -29,6 +29,7 @@ export type BarnesSimpleCategoryResults = {
 };
 
 const PLACEHOLD_TEAM_NAME = 'Empty';
+const EXHIB_PENALTY_CODE = 'Exhib';
 
 /**
  * The max possible number of points for this event given the boat class and event type
@@ -302,12 +303,13 @@ export const barnesPointsImpl = (
 
   // check if there were teams entered which scored 0 points,
   // but which still need to be represented on the results page
+  // exhibition crews are ignored
   const scoringTeams = new Set<string>(teamPoints.keys());
   const missingTeams = new Set<string>();
   resultData.results.forEach((event) =>
     event.entries.forEach((entry) => {
       const teamName = trimCrewName(entry.Crew);
-      if (!scoringTeams.has(teamName) && teamName != PLACEHOLD_TEAM_NAME) {
+      if (!scoringTeams.has(teamName) && teamName != PLACEHOLD_TEAM_NAME && entry.PenaltyCode != EXHIB_PENALTY_CODE) {
         missingTeams.add(teamName);
       }
     }),

--- a/src/calculators/BarnesPointsCalc.ts
+++ b/src/calculators/BarnesPointsCalc.ts
@@ -14,12 +14,18 @@ export type TeamPoints = {
   points: number;
 };
 
-export type BarnesCategoryResults = {
+export type BarnesFullCategoryResults = {
   combined: TeamPoints[];
   mensScull: TeamPoints[];
   womensScull: TeamPoints[];
   mensSweep: TeamPoints[];
   womensSweep: TeamPoints[];
+};
+
+export type BarnesSimpleCategoryResults = {
+  combined: TeamPoints[];
+  mens: TeamPoints[];
+  womens: TeamPoints[];
 };
 
 const PLACEHOLD_TEAM_NAME = 'Empty';
@@ -154,12 +160,12 @@ const trimCrewName = (crewName: string) => {
 };
 
 /**
- * Sort teams in each category by number of points
+ * Sort teams in each category by number of points, including sweep/sculling split out
  *
  * @param results
  * @returns
  */
-const finalizeResults = (results: Map<string, BarnesPointsTeamResults>): BarnesCategoryResults => {
+const finalizeFullResults = (results: Map<string, BarnesPointsTeamResults>): BarnesFullCategoryResults => {
   return {
     combined: Array.from(results.entries())
       .sort((a, b) => b[1].combined - a[1].combined)
@@ -180,6 +186,28 @@ const finalizeResults = (results: Map<string, BarnesPointsTeamResults>): BarnesC
     womensSweep: Array.from(results.entries())
       .sort((a, b) => b[1].womensSweep - a[1].womensSweep)
       .map((value) => ({ team: value[0], points: value[1].womensSweep })),
+  };
+};
+
+/**
+ * Sort teams in each category by number of points
+ *
+ * @param results
+ * @returns
+ */
+const finalizeResults = (results: Map<string, BarnesPointsTeamResults>) => {
+  return {
+    combined: Array.from(results.entries())
+      .sort((a, b) => b[1].combined - a[1].combined)
+      .map((value) => ({ team: value[0], points: value[1].combined })),
+
+    mens: Array.from(results.entries())
+      .sort((a, b) => b[1].mensScull + b[1].mensSweep - (a[1].mensScull + a[1].mensSweep))
+      .map((value) => ({ team: value[0], points: value[1].mensScull + value[1].mensSweep })),
+
+    womens: Array.from(results.entries())
+      .sort((a, b) => b[1].womensScull + b[1].womensSweep - (a[1].womensScull + a[1].womensSweep))
+      .map((value) => ({ team: value[0], points: value[1].womensScull + value[1].womensSweep })),
   };
 };
 
@@ -236,9 +264,11 @@ export const calculateEventTeamPoints = (eventResult: EventResult, useScaledEven
  * Calculate points based on the Barnes Scoring System, as described by MSRA:
  * https://sites.google.com/site/msrahome/regatta-rules/home
  */
-export const barnesPointsCalc = (resultData: Results, useScaledEvents: boolean): BarnesCategoryResults => {
+export const barnesPointsImpl = (
+  resultData: Results,
+  useScaledEvents: boolean,
+): Map<string, BarnesPointsTeamResults> => {
   const teamPoints = new Map<string, BarnesPointsTeamResults>();
-
   resultData.results.forEach((eventResult) => {
     const candidateMatches = [/WOMEN/, /GIRL/];
     const isWomensEvent = candidateMatches.some((candidate) => eventResult.Event.toUpperCase().search(candidate) != -1);
@@ -292,6 +322,26 @@ export const barnesPointsCalc = (resultData: Results, useScaledEvents: boolean):
       mensSweep: 0,
     }),
   );
+
+  return teamPoints;
+};
+
+/**
+ * Calculate points based on the Barnes Scoring System, as described by MSRA:
+ * https://sites.google.com/site/msrahome/regatta-rules/home
+ */
+export const barnesFullPointsCalc = (resultData: Results, useScaledEvents: boolean): BarnesFullCategoryResults => {
+  const teamPoints = barnesPointsImpl(resultData, useScaledEvents);
+
+  return finalizeFullResults(teamPoints);
+};
+
+/**
+ * Calculate points based on the Barnes Scoring System, as described by MSRA:
+ * https://sites.google.com/site/msrahome/regatta-rules/home
+ */
+export const barnesPointsCalc = (resultData: Results, useScaledEvents: boolean): BarnesSimpleCategoryResults => {
+  const teamPoints = barnesPointsImpl(resultData, useScaledEvents);
 
   return finalizeResults(teamPoints);
 };

--- a/src/components/BarnesPoints.tsx
+++ b/src/components/BarnesPoints.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Table from '@mui/material/Table';
 import { TableBody, TableCell, TableHead, TableRow, styled } from '@mui/material';
 import { Results } from '../common/CrewTimerTypes';
-import { barnesPointsCalc } from '../calculators/BarnesPointsCalc';
+import { barnesFullPointsCalc, barnesPointsCalc } from '../calculators/BarnesPointsCalc';
 
 const categories = [
   'Combined Points',
@@ -11,6 +11,8 @@ const categories = [
   "Women's Scull Points",
   "Men's Scull Points",
 ];
+
+const simpleCategories = ['Combined Points', "Women's Points", "Men's Points"];
 
 const StyledTableRow = styled(TableRow)(({ theme }) => ({
   '&:nth-of-type(odd)': {
@@ -26,49 +28,84 @@ const HeaderTableCell = styled(TableCell)(() => ({
   fontWeight: 'bold',
 }));
 
-const BarnesPoints: React.FC<{ results: Results; useScaledEvents: boolean }> = ({ results, useScaledEvents }) => {
+export interface BarnesPointsProps {
+  results: Results;
+  useScaledEvents: boolean;
+  useScullSweepCategories: boolean;
+}
+
+const getTableRows = (results: Results, useScaledEvents: boolean, useScullSweepCategories: boolean) => {
+  if (useScullSweepCategories === true) {
+    const points = barnesFullPointsCalc(results, useScaledEvents);
+    return points.combined.map((_, idx) => (
+      <StyledTableRow key={idx}>
+        <TableCell>{idx + 1}</TableCell>
+        <TableCell>{points.combined[idx].team}</TableCell>
+        <TableCell align='right'>{points.combined[idx].points.toFixed(1)}</TableCell>
+        <TableCell>{points.womensSweep[idx].team}</TableCell>
+        <TableCell align='right'>{points.womensSweep[idx].points.toFixed(1)}</TableCell>
+        <TableCell>{points.mensSweep[idx].team}</TableCell>
+        <TableCell align='right'>{points.mensSweep[idx].points.toFixed(1)}</TableCell>
+        <TableCell>{points.womensScull[idx].team}</TableCell>
+        <TableCell align='right'>{points.womensScull[idx].points.toFixed(1)}</TableCell>
+        <TableCell>{points.mensScull[idx].team}</TableCell>
+        <TableCell align='right'>{points.mensScull[idx].points.toFixed(1)}</TableCell>
+      </StyledTableRow>
+    ));
+  }
+
   const points = barnesPointsCalc(results, useScaledEvents);
+  return points.combined.map((_, idx) => (
+    <StyledTableRow key={idx}>
+      <TableCell>{idx + 1}</TableCell>
+      <TableCell>{points.combined[idx].team}</TableCell>
+      <TableCell align='right'>{points.combined[idx].points.toFixed(1)}</TableCell>
+      <TableCell>{points.womens[idx].team}</TableCell>
+      <TableCell align='right'>{points.womens[idx].points.toFixed(1)}</TableCell>
+      <TableCell>{points.mens[idx].team}</TableCell>
+      <TableCell align='right'>{points.mens[idx].points.toFixed(1)}</TableCell>
+    </StyledTableRow>
+  ));
+};
+
+const BarnesPoints: React.FC<BarnesPointsProps> = ({ results, useScaledEvents, useScullSweepCategories }) => {
+  const pointsCategories = useScullSweepCategories ? categories : simpleCategories;
   return (
     <Table size='small'>
       <TableHead>
         <TableRow>
           <HeaderTableCell key='place'>Place</HeaderTableCell>
-          {categories.map((category) => [
+          {pointsCategories.map((category) => [
             <HeaderTableCell key={category}>{category}</HeaderTableCell>,
             <HeaderTableCell key={category + '_padding'}></HeaderTableCell>,
           ])}
         </TableRow>
       </TableHead>
-      <TableBody>
-        {points.combined.map((_, idx) => (
-          <StyledTableRow key={idx}>
-            <TableCell>{idx + 1}</TableCell>
-            <TableCell>{points.combined[idx].team}</TableCell>
-            <TableCell align='right'>{points.combined[idx].points.toFixed(1)}</TableCell>
-            <TableCell>{points.womensSweep[idx].team}</TableCell>
-            <TableCell align='right'>{points.womensSweep[idx].points.toFixed(1)}</TableCell>
-            <TableCell>{points.mensSweep[idx].team}</TableCell>
-            <TableCell align='right'>{points.mensSweep[idx].points.toFixed(1)}</TableCell>
-            <TableCell>{points.womensScull[idx].team}</TableCell>
-            <TableCell align='right'>{points.womensScull[idx].points.toFixed(1)}</TableCell>
-            <TableCell>{points.mensScull[idx].team}</TableCell>
-            <TableCell align='right'>{points.mensScull[idx].points.toFixed(1)}</TableCell>
-          </StyledTableRow>
-        ))}
-      </TableBody>
+      <TableBody>{getTableRows(results, useScaledEvents, useScullSweepCategories)}</TableBody>
     </Table>
   );
 };
 
 /**
- * Render team points calculated by the Barnes Points system for all points categories.
+ * Render team points calculated by the Barnes Points system for points categories including scull/sweep.
  * An event's point values are scaled by Novice/Junior/Varsity category.
  *
  * @param points - An array of points results in sorted order.
  *
  */
-export const BarnesPointsWeighted: React.FC<{ results: Results }> = ({ results }) => {
-  return <BarnesPoints useScaledEvents={true} results={results} />; // For now use the same result.  TODO: Add Trophies.
+export const BarnesFullWeighted: React.FC<{ results: Results }> = ({ results }) => {
+  return <BarnesPoints useScullSweepCategories={true} useScaledEvents={true} results={results} />;
+};
+
+/**
+ * Render team points calculated by the Barnes Points system for basic points categories.
+ * An event's point values are scaled by Novice/Junior/Varsity category.
+ *
+ * @param points - An array of points results in sorted order.
+ *
+ */
+export const BarnesSimpleWeighted: React.FC<{ results: Results }> = ({ results }) => {
+  return <BarnesPoints useScullSweepCategories={false} useScaledEvents={true} results={results} />;
 };
 
 /**
@@ -79,5 +116,5 @@ export const BarnesPointsWeighted: React.FC<{ results: Results }> = ({ results }
  *
  */
 export const BarnesPointsTraditional: React.FC<{ results: Results }> = ({ results }) => {
-  return <BarnesPoints useScaledEvents={false} results={results} />; // For now use the same result.  TODO: Add Trophies.
+  return <BarnesPoints useScullSweepCategories={true} useScaledEvents={false} results={results} />;
 };

--- a/src/example/App.tsx
+++ b/src/example/App.tsx
@@ -14,7 +14,8 @@ import { PointsViewers } from '..';
 
 const ResultsForViewer: { [key: string]: Results } = {
   Basic: simpleResults as unknown as Results,
-  BarnesWeighted: barnesJrNovice as unknown as Results,
+  BarnesFullWeighted: barnesJrNovice as unknown as Results,
+  BarnesSimpleWeighted: barnesJrNovice as unknown as Results,
   BarnesTraditional: barnesTraditional as unknown as Results,
   ACA: acaResults as unknown as Results,
   ACANat: acaResults as unknown as Results,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Results } from './common/CrewTimerTypes';
 import { SimpleTeamPoints } from './components/SimpleTeamPoints';
-import { BarnesPointsTraditional, BarnesPointsWeighted } from './components/BarnesPoints';
+import { BarnesPointsTraditional, BarnesFullWeighted, BarnesSimpleWeighted } from './components/BarnesPoints';
 import { ACATeamPoints, ACANationalsPoints } from './components/ACATeamPoints';
 
 export interface PointsViewerInfo {
@@ -20,9 +20,14 @@ export const PointsViewers: PointsViewerInfo[] = [
     ui: SimpleTeamPoints,
   },
   {
-    name: 'Barnes - Michigan States & Mitten Series',
-    key: 'BarnesWeighted',
-    ui: BarnesPointsWeighted,
+    name: 'Barnes - Mitten Series',
+    key: 'BarnesFullWeighted',
+    ui: BarnesFullWeighted,
+  },
+  {
+    name: 'Barnes - Michigan States',
+    key: 'BarnesSimpleWeighted',
+    ui: BarnesSimpleWeighted,
   },
   {
     name: 'Barnes Points Traditional',

--- a/tests/barnes-points.test.tsx
+++ b/tests/barnes-points.test.tsx
@@ -12,19 +12,18 @@ import { Results } from '../src/common/CrewTimerTypes';
 it('barnes points full weighted', async () => {
   const points = barnesFullPointsCalc(regattaResults as unknown as Results, true);
   // check that non-scoring teams are included in the display list
-  expect(points.combined.length).toEqual(9);
-  expect(points.womensScull.length).toEqual(9);
-  expect(points.mensScull.length).toEqual(9);
-  expect(points.womensSweep.length).toEqual(9);
-  expect(points.mensSweep.length).toEqual(9);
+  expect(points.combined.length).toEqual(8);
+  expect(points.womensScull.length).toEqual(8);
+  expect(points.mensScull.length).toEqual(8);
+  expect(points.womensSweep.length).toEqual(8);
+  expect(points.mensSweep.length).toEqual(8);
 
   const sp = points.combined.find((entry) => entry.team == 'Slow Poke');
   expect(sp).toBeDefined();
   expect(sp?.points).toEqual(0);
 
   const ifc = points.combined.find((entry) => entry.team == 'Illegally Fast Composite');
-  expect(ifc).toBeDefined();
-  expect(ifc?.points).toEqual(0);
+  expect(ifc).toBeUndefined();
 
   // check teams with B entries
   let mb = points.combined.find((entry) => entry.team === 'Mount Baker');
@@ -62,23 +61,22 @@ it('barnes points full weighted', async () => {
   expect(ls_msweep?.points).toEqual(28.8);
 
   // validate combined points value and order
-  expect(points.combined.map((entry) => entry.points)).toEqual([65.95, 53.9, 46.4, 42.1, 37.8, 11.6, 5.8, 0, 0]);
+  expect(points.combined.map((entry) => entry.points)).toEqual([65.95, 53.9, 46.4, 42.1, 37.8, 11.6, 5.8, 0]);
 });
 
 it('barnes points simple weighted', async () => {
   const points = barnesPointsCalc(regattaResults as unknown as Results, true);
   // check that non-scoring teams are included in the display list
-  expect(points.combined.length).toEqual(9);
-  expect(points.womens.length).toEqual(9);
-  expect(points.mens.length).toEqual(9);
+  expect(points.combined.length).toEqual(8);
+  expect(points.womens.length).toEqual(8);
+  expect(points.mens.length).toEqual(8);
 
   const sp = points.combined.find((entry) => entry.team == 'Slow Poke');
   expect(sp).toBeDefined();
   expect(sp?.points).toEqual(0);
 
   const ifc = points.combined.find((entry) => entry.team == 'Illegally Fast Composite');
-  expect(ifc).toBeDefined();
-  expect(ifc?.points).toEqual(0);
+  expect(ifc).toBeUndefined();
 
   // check teams with B entries
   let mb = points.combined.find((entry) => entry.team === 'Mount Baker');
@@ -106,25 +104,24 @@ it('barnes points simple weighted', async () => {
   expect(ls_mens?.points).toEqual(37.8);
 
   // validate combined points value and order
-  expect(points.combined.map((entry) => entry.points)).toEqual([65.95, 53.9, 46.4, 42.1, 37.8, 11.6, 5.8, 0, 0]);
+  expect(points.combined.map((entry) => entry.points)).toEqual([65.95, 53.9, 46.4, 42.1, 37.8, 11.6, 5.8, 0]);
 });
 
 it('barnes points traditional', async () => {
   const points = barnesFullPointsCalc(regattaResults as unknown as Results, false);
-  // check that non-scoring teams are included in the display list
-  expect(points.combined.length).toEqual(9);
-  expect(points.womensScull.length).toEqual(9);
-  expect(points.mensScull.length).toEqual(9);
-  expect(points.womensSweep.length).toEqual(9);
-  expect(points.mensSweep.length).toEqual(9);
+  // check that non-scoring non-exhib-only teams are included in the display list
+  expect(points.combined.length).toEqual(8);
+  expect(points.womensScull.length).toEqual(8);
+  expect(points.mensScull.length).toEqual(8);
+  expect(points.womensSweep.length).toEqual(8);
+  expect(points.mensSweep.length).toEqual(8);
 
   const sp = points.combined.find((entry) => entry.team == 'Slow Poke');
   expect(sp).toBeDefined();
   expect(sp?.points).toEqual(0);
 
   const ifc = points.combined.find((entry) => entry.team == 'Illegally Fast Composite');
-  expect(ifc).toBeDefined();
-  expect(ifc?.points).toEqual(0);
+  expect(ifc).toBeUndefined();
 
   // check teams with B entries
   let mb = points.combined.find((entry) => entry.team === 'Mount Baker');
@@ -162,7 +159,7 @@ it('barnes points traditional', async () => {
   expect(ls_msweep?.points).toEqual(32);
 
   // validate combined points value and order
-  expect(points.combined.map((entry) => entry.points)).toEqual([78.75, 58.5, 56, 48.5, 41, 14, 7, 0, 0]);
+  expect(points.combined.map((entry) => entry.points)).toEqual([78.75, 58.5, 56, 48.5, 41, 14, 7, 0]);
 });
 
 it('barnes points by number of entries', async () => {

--- a/tests/barnes-points.test.tsx
+++ b/tests/barnes-points.test.tsx
@@ -1,6 +1,7 @@
 import regattaResults from './data/crewtimer-results-dev-r12033-export-jr-nov-events.json';
 import simpleResults from './data/crewtimer-results-dev-final-counts.json';
 import {
+  barnesFullPointsCalc,
   barnesPointsCalc,
   calculateEventTeamPoints,
   calculateNumberOfEntries,
@@ -8,8 +9,8 @@ import {
 import { expect, it } from '@jest/globals';
 import { Results } from '../src/common/CrewTimerTypes';
 
-it('barnes points weighted', async () => {
-  const points = barnesPointsCalc(regattaResults as unknown as Results, true);
+it('barnes points full weighted', async () => {
+  const points = barnesFullPointsCalc(regattaResults as unknown as Results, true);
   // check that non-scoring teams are included in the display list
   expect(points.combined.length).toEqual(9);
   expect(points.womensScull.length).toEqual(9);
@@ -64,8 +65,52 @@ it('barnes points weighted', async () => {
   expect(points.combined.map((entry) => entry.points)).toEqual([65.95, 53.9, 46.4, 42.1, 37.8, 11.6, 5.8, 0, 0]);
 });
 
+it('barnes points simple weighted', async () => {
+  const points = barnesPointsCalc(regattaResults as unknown as Results, true);
+  // check that non-scoring teams are included in the display list
+  expect(points.combined.length).toEqual(9);
+  expect(points.womens.length).toEqual(9);
+  expect(points.mens.length).toEqual(9);
+
+  const sp = points.combined.find((entry) => entry.team == 'Slow Poke');
+  expect(sp).toBeDefined();
+  expect(sp?.points).toEqual(0);
+
+  const ifc = points.combined.find((entry) => entry.team == 'Illegally Fast Composite');
+  expect(ifc).toBeDefined();
+  expect(ifc?.points).toEqual(0);
+
+  // check teams with B entries
+  let mb = points.combined.find((entry) => entry.team === 'Mount Baker');
+  expect(mb).toBeDefined();
+  expect(mb?.points).toEqual(65.95);
+  mb = points.womens.find((entry) => entry.team === 'Mount Baker');
+  expect(mb).toBeDefined();
+  expect(mb?.points).toEqual(58);
+
+  const glc_mens = points.mens.find((entry) => entry.team === 'Green Lake Crew');
+  expect(glc_mens).toBeDefined();
+  expect(glc_mens?.points).toEqual(51);
+
+  // 4th place, 5 boats in final - .1 * 15 = 1.5
+  const mb_mens = points.mens.find((entry) => entry.team === 'Mount Baker');
+  expect(mb_mens).toBeDefined();
+  expect(mb_mens?.points).toEqual(7.95);
+
+  const glc_womens = points.womens.find((entry) => entry.team === 'Green Lake Crew');
+  expect(glc_womens).toBeDefined();
+  expect(glc_womens?.points).toEqual(2.9);
+
+  const ls_mens = points.mens.find((entry) => entry.team === 'Lakeside School');
+  expect(ls_mens).toBeDefined();
+  expect(ls_mens?.points).toEqual(37.8);
+
+  // validate combined points value and order
+  expect(points.combined.map((entry) => entry.points)).toEqual([65.95, 53.9, 46.4, 42.1, 37.8, 11.6, 5.8, 0, 0]);
+});
+
 it('barnes points traditional', async () => {
-  const points = barnesPointsCalc(regattaResults as unknown as Results, false);
+  const points = barnesFullPointsCalc(regattaResults as unknown as Results, false);
   // check that non-scoring teams are included in the display list
   expect(points.combined.length).toEqual(9);
   expect(points.womensScull.length).toEqual(9);


### PR DESCRIPTION
To be compliant with the [points system described by SRAM](https://docs.google.com/document/d/1qAOkbzIqBRwsFdp41-SwlJbDn5Z67PjUH2iwQ9ioLLA/edit), there must be points categories for Combined, Men's, and Women's , without the Sculling/Sweep split.

Additional adresses a display issues for crews which ONLY have exhibition boats, which should be treated as if they never existed, and should be excluded from the points display.