### PR TITLE
Use explcit configuration, not defaults

### DIFF
--- a/src/calculators/MSRATeamDivisionPointsCalc.ts
+++ b/src/calculators/MSRATeamDivisionPointsCalc.ts
@@ -67,7 +67,7 @@ export const pointsByDivision = (resultsData: Results): Map<string, TeamResult[]
 
   maybeAdjustDivisions(divisionMinimums);
 
-  const allTeamPoints = barnesPointsImpl(resultsData, true, true, true);
+  const allTeamPoints = barnesPointsImpl(resultsData, true, false, true);
 
   const finalPoints = new Map<string, TeamResult[]>();
   DIVISION_SIZES.forEach((_, divName) => finalPoints.set(divName, []));

--- a/src/calculators/MSRATeamDivisionPointsCalc.ts
+++ b/src/calculators/MSRATeamDivisionPointsCalc.ts
@@ -67,7 +67,7 @@ export const pointsByDivision = (resultsData: Results): Map<string, TeamResult[]
 
   maybeAdjustDivisions(divisionMinimums);
 
-  const allTeamPoints = barnesPointsImpl(resultsData, true);
+  const allTeamPoints = barnesPointsImpl(resultsData, true, true, true);
 
   const finalPoints = new Map<string, TeamResult[]>();
   DIVISION_SIZES.forEach((_, divName) => finalPoints.set(divName, []));


### PR DESCRIPTION
Explicitly set the configuration values for the Barnes points calculation when used for Divisoin points trophies. The deafaults when left undefined are not the desired settings.